### PR TITLE
main <- 検索結果のクラスターが画面外にある場合に自動的に地図を移動

### DIFF
--- a/web/src/components/Map.tsx
+++ b/web/src/components/Map.tsx
@@ -109,14 +109,16 @@ export default function Map({ className = '' }: MapProps) {
     const calculateBounds = useCallback((data: PreschoolData[]) => {
         if (data.length === 0) return null;
         
-        const coordinates = data.map(preschool => preschool.coordinates);
-        const lngs = coordinates.map(coord => coord[0]);
-        const lats = coordinates.map(coord => coord[1]);
-        
-        const bounds = [
-            [Math.min(...lngs), Math.min(...lats)],
-            [Math.max(...lngs), Math.max(...lats)]
-        ] as [[number, number], [number, number]];
+const bounds = data.reduce<[[number, number], [number, number]]>((acc, { coordinates }) => {
+    const [lng, lat] = coordinates;
+    return [
+        [Math.min(acc[0][0], lng), Math.min(acc[0][1], lat)],
+        [Math.max(acc[1][0], lng), Math.max(acc[1][1], lat)],
+    ];
+}, [
+    [data[0].coordinates[0], data[0].coordinates[1]],
+    [data[0].coordinates[0], data[0].coordinates[1]],
+]);
         
         return bounds;
     }, []);

--- a/web/src/components/Map.tsx
+++ b/web/src/components/Map.tsx
@@ -127,8 +127,8 @@ const bounds = data.reduce<[[number, number], [number, number]]>((acc, { coordin
     const moveMapToClusters = useCallback(() => {
         if (!map.current || !map.current.isStyleLoaded() || filteredData.length === 0) return;
 
-        // 少し遅延を入れてクラスターが完全に描画されるのを待つ
-        setTimeout(() => {
+        // マップのレンダリングが完了したタイミングで実行
+        map.current.once('idle', () => {
             if (!map.current) return;
 
             const bounds = calculateBounds(filteredData);
@@ -153,7 +153,7 @@ const bounds = data.reduce<[[number, number], [number, number]]>((acc, { coordin
                     });
                 }
             }
-        }, 100);
+        });
     }, [filteredData, calculateBounds]);
 
     useEffect(() => {


### PR DESCRIPTION
## コミット種別
- [x] add：新機能や新しいファイルの追加
- [ ] update：機能修正（バグではない）
- [ ] delete：ファイルの削除
- [ ] fix：バグ修正
- [ ] style：空白・セミコロン・整形・コードフォーマット等の修正
- [ ] refactor：挙動を変えずにコードを改善
- [ ] perf：パフォーマンス改善のためのコード変更
- [ ] chore：ビルド・補助ツール・ライブラリ・開発環境の変更
- [ ] docs：ドキュメントのみの変更
- [ ] upgrade：バージョンアップ
- [ ] revert：変更取り消し

## 変更点
* 検索結果のクラスターが画面外にある場合に自動的に地図を移動する機能を追加
* `calculateBounds`関数を追加：検索結果の保育園座標からクラスター全体の境界を計算
* `moveMapToClusters`関数を追加：現在のビューポートとクラスター境界を比較し、必要に応じて地図を移動
* 検索結果更新時の自動移動用useEffectを追加：`filteredData`が変更されるたびに`moveMapToClusters`を実行
* 100msの遅延を設けてクラスターの描画完了を待機
* 最大ズームレベルを15に制限して適切な表示範囲を確保

## 動作確認内容
* 保育園名での検索時に、検索結果のクラスターが画面外にある場合に地図が自動移動することを確認
* 年齢クラスと空き数での絞り込み時に、結果のクラスターが画面内に表示されるように地図が移動することを確認
* フィルターをリセットした際に、全保育園のクラスターが画面内に表示されるように地図が移動することを確認
* 検索結果が既に画面内にある場合は地図が移動しないことを確認
* 地図の移動が滑らかなアニメーションで行われることを確認

## その他
* レビュワーへの参考情報：
  - MapLibre GL JSの`fitBounds`メソッドを使用して地図を移動
  - クラスターの境界計算は最小・最大の経度・緯度を取得して実装
  - 現在のビューポートとの比較は`getBounds()`メソッドを使用
* 実装上の懸念点や注意点：
  - 100msの遅延はクラスターの描画完了を待つため必要（短すぎると移動が正しく動作しない可能性）
  - `maxZoom: 15`の制限により、過度にズームインすることを防止
  - `filteredData`の変更時に毎回実行されるため、パフォーマンスへの影響は軽微
  - 空の検索結果の場合は地図移動を実行しないようガード条件を設定