### PR TITLE
main <- 検索件数の表示を追加

### DIFF
--- a/web/src/components/Map.tsx
+++ b/web/src/components/Map.tsx
@@ -328,7 +328,12 @@ export default function Map({ className = '' }: MapProps) {
                 }}
             >
                 <div className="flex justify-between items-center mb-4">
-                    <h2 className="text-xl font-bold text-gray-800">保育園検索</h2>
+                    <div>
+                        <h2 className="text-xl font-bold text-gray-800">保育園検索</h2>
+                        <p className="text-sm text-gray-600 mt-1">
+                            検索結果: <span className="font-semibold text-blue-600">{filteredData.length}</span>件
+                        </p>
+                    </div>
                     <button
                         onClick={() => setIsFilterPanelOpen(false)}
                         className="text-gray-500 hover:text-gray-700 p-1 rounded-md hover:bg-gray-100 transition-colors duration-150 cursor-pointer"

--- a/web/src/components/Map.tsx
+++ b/web/src/components/Map.tsx
@@ -331,7 +331,7 @@ export default function Map({ className = '' }: MapProps) {
                     <div>
                         <h2 className="text-xl font-bold text-gray-800">保育園検索</h2>
                         <p className="text-sm text-gray-600 mt-1">
-                            検索結果: <span className="font-semibold text-blue-600">{filteredData.length}</span>件
+                            検索結果: <span className="font-semibold text-blue-600">{filteredData.length.toLocaleString('ja-JP')}</span>件
                         </p>
                     </div>
                     <button


### PR DESCRIPTION
## コミット種別
- [x] add：新機能や新しいファイルの追加
- [ ] update：機能修正（バグではない）
- [ ] delete：ファイルの削除
- [ ] fix：バグ修正
- [ ] style：空白・セミコロン・整形・コードフォーマット等の修正
- [ ] refactor：挙動を変えずにコードを改善
- [ ] perf：パフォーマンス改善のためのコード変更
- [ ] chore：ビルド・補助ツール・ライブラリ・開発環境の変更
- [ ] docs：ドキュメントのみの変更
- [ ] upgrade：バージョンアップ
- [ ] revert：変更取り消し

## 変更点
* フィルターパネルに検索結果の件数を表示する機能を追加
* `filteredData.length`を使用してリアルタイムで検索結果件数を表示
* 検索結果件数を青色で強調表示し、ユーザビリティを向上
* 保育園名検索、年齢クラス絞り込み、フィルターリセットの全ての操作で件数が更新されることを確認

## 動作確認内容
* 保育園名で検索した際に件数が正しく表示されることを確認
* 年齢クラスと空き数で絞り込みした際に件数が更新されることを確認
* 複数の条件を組み合わせた検索で件数が正確に計算されることを確認
* フィルターをリセットした際に全件数が表示されることを確認
* 検索条件をクリアした際に件数が0件になることを確認

## その他
* 検索結果件数は`filteredData`の配列長を直接参照しているため、パフォーマンスへの影響は最小限
* 件数表示のスタイリングは既存のデザインシステムに合わせて実装
* 将来的に検索結果の詳細情報（例：空きのある保育園数など）も表示可能な構造